### PR TITLE
Refactor to make it work under RakuAST

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+lib/.precomp
+.precomp

--- a/META6.json
+++ b/META6.json
@@ -12,6 +12,7 @@
         "Slang::Otherwise": "lib/Slang/Otherwise.rakumod"
     },
     "depends": [
+      "Slangify:ver<0.0.2+>:auth<zef:lizmat>"
     ],
     "source-url": "https://github.com/0racle/raku-Slang-Otherwise"
 }

--- a/lib/Slang/Otherwise.rakumod
+++ b/lib/Slang/Otherwise.rakumod
@@ -1,48 +1,59 @@
-role Otherwise::Grammar {
+# Helper sub to do a HLL lookup in a NQP Match object
+my sub lookup(Mu \match, str $key) {
+    use nqp;
+    nqp::atkey(
+      nqp::findmethod(match,'hash')(match),
+      $key
+    ).?ast
+}
 
-    rule statement_control:sym<for> {
-        <sym><.kok> {}
-        <.vetPerl5Syntax>
-        <xblock(2)> {}
-        [ 'otherwise' <elseblock=pblock> ]?
+my role Otherwise::Grammar {
+    rule statement-control:sym<for> {
+        <.block-for><.kok> {}
+        <.vetPerlForSyntax>
+        :my $*GOAL := '{';
+        :my $*BORG := {};
+        <EXPR>
+        <pointy-block>
+        [ otherwise $<otherwise>=<.pointy-block> ]?
     }
+}
+my role Otherwise::Actions {
+    method statement-control:sym<for>(Mu $/) {
+        if lookup($/, 'otherwise') -> $otherwise {
+            callsame.replace-otherwise($otherwise);
+        }
+    }
+}
 
-    rule vetPerl5Syntax {
+my role Otherwise::Grammar::Legacy {
+    rule vetPerlForSyntax {
         [ <?before 'my'? '$'\w+\s+'(' >
             <.typed_panic: 'X::Syntax::P5'> ]?
         [ <?before '(' <.EXPR>? ';' <.EXPR>? ';' <.EXPR>? ')' >
             <.obs('C-style "for (;;)" loop', '"loop (;;)"')> ]?
     }
 
+    rule statement_control:sym<for> {
+        <sym><.kok> {}
+        <.vetPerlForSyntax>
+        <xblock(2)> {}
+        [ otherwise <elseblock=pblock> ]?
+    }
 }
 
-role Otherwise::Actions {
-    use nqp;
-    use QAST:from<NQP>;
-
-    sub lookup(Mu \match, \key) {
-        nqp::atkey(
-            nqp::findmethod(match, 'hash')(match),
-            key
-        ).?ast
-    }
-
-    method statement_control:sym<for> (Mu $match) {
+my role Otherwise::Actions::Legacy {
+    method statement_control:sym<for>(Mu $/) {
         my $forloop := callsame;
-        if lookup($match, 'elseblock') -> $elseblock {
-            $match.make:
-                QAST::Op.new: :op<unless>, $forloop,
-                QAST::Op.new: :op<call>,   $elseblock
+        if lookup($/, 'elseblock') -> $elseblock {
+            use QAST:from<NQP>;
+            make QAST::Op.new: :op<unless>,
+              $forloop,
+              QAST::Op.new: :op<call>,
+                $elseblock;
         }
     }
-
 }
 
-sub EXPORT {
-    $*LANG.define_slang:
-        "MAIN",
-        $*LANG.slangs<MAIN>         but Otherwise::Grammar,
-        $*LANG.slangs<MAIN-actions> but Otherwise::Actions;
-
-    return hash();
-}
+use Slangify Otherwise::Grammar, Otherwise::Actions,
+  Otherwise::Grammar::Legacy, Otherwise::Actions::Legacy;

--- a/t/01-basic.rakutest
+++ b/t/01-basic.rakutest
@@ -1,0 +1,40 @@
+use v6.c;
+use Test;
+use Slang::Otherwise;
+
+plan 4;
+
+my @a;
+
+for @a {
+    flunk "Should not have flunked";
+}
+otherwise {
+    pass "executing the otherwise";
+}
+
+my $result := do for @a {
+    666
+}
+otherwise {
+    42
+}
+is-deeply $result, 42, 'Did the otherwise return the value';
+
+@a.push: 42;
+for @a {
+    is-deeply $_, 42, 'Did we run the loop';
+}
+otherwise {
+    flunk "Should not have flunked";
+}
+
+$result := do for @a {
+    $_
+}
+otherwise {
+    666;
+}
+is-deeply $result, (42,), 'Did the for loop return the value';
+
+# vim: ft=perl6 expandtab sw=4


### PR DESCRIPTION
- Add dependency to Slangify to abstract the slangification in a central place, to allow for possible future changes behind the scenes.
- Add preliminary support to allow running under RakuAST.  This requires a post 2023.09 version of Rakudo, specifically 9b29fdcab61
- Add some basic tests, also in "do" context
- Add .gitignore for convenience
- Does NOT bump version yet

For the record: thank you for creating this slang after the discussions after Damian's blog post, now 4 years ago.  If you think it would be better if this were a Raku community module, transfer the repo to raku-community-modules, and I will take care of it there.  Of course, if you would like to keep taking care of this module, that's also ok!